### PR TITLE
Bump `tf_codebuild` version to `0.3.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Module directory
 .terraform/
+
+.idea
+*.iml

--- a/main.tf
+++ b/main.tf
@@ -129,12 +129,12 @@ data "aws_iam_policy_document" "codebuild" {
 module "build" {
   source        = "git::https://github.com/cloudposse/tf_codebuild.git?ref=tags/0.3.0"
   namespace     = "${var.namespace}"
-  name          = "${var.name}-build"
+  name          = "${var.name}"
   stage         = "${var.stage}"
   image         = "${var.build_image}"
   instance_size = "${var.build_instance_size}"
   delimiter     = "${var.delimiter}"
-  attributes    = "${var.attributes}"
+  attributes    = "${lower(join(var.delimiter, compact(concat(var.attributes, list("build")))))}"
   tags          = "${var.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,12 @@
 # Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 resource "aws_s3_bucket" "default" {
@@ -14,8 +17,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_iam_role" "default" {
-  name = "${module.label.id}"
-
+  name               = "${module.label.id}"
   assume_role_policy = "${data.aws_iam_policy_document.assume.json}"
 }
 
@@ -37,7 +39,7 @@ data "aws_iam_policy_document" "assume" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  role   = "${aws_iam_role.default.id}"
+  role       = "${aws_iam_role.default.id}"
   policy_arn = "${aws_iam_policy.default.arn}"
 }
 
@@ -71,7 +73,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_iam_role_policy_attachment" "s3" {
-  role   = "${aws_iam_role.default.id}"
+  role       = "${aws_iam_role.default.id}"
   policy_arn = "${aws_iam_policy.s3.arn}"
 }
 
@@ -102,10 +104,9 @@ data "aws_iam_policy_document" "s3" {
 }
 
 resource "aws_iam_role_policy_attachment" "codebuild" {
-  role   = "${aws_iam_role.default.id}"
+  role       = "${aws_iam_role.default.id}"
   policy_arn = "${aws_iam_policy.codebuild.arn}"
 }
-
 
 resource "aws_iam_policy" "codebuild" {
   name   = "${module.label.id}-codebuild"
@@ -136,7 +137,7 @@ module "build" {
 }
 
 resource "aws_iam_role_policy_attachment" "codebuild_s3" {
-  role   = "${module.build.role_arn}"
+  role       = "${module.build.role_arn}"
   policy_arn = "${aws_iam_policy.s3.arn}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ module "build" {
   image         = "${var.build_image}"
   instance_size = "${var.build_instance_size}"
   delimiter     = "${var.delimiter}"
-  attributes    = "${lower(join(var.delimiter, compact(concat(var.attributes, list("build")))))}"
+  attributes    = "${concat(var.attributes, list("build"))}"
   tags          = "${var.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -127,13 +127,15 @@ data "aws_iam_policy_document" "codebuild" {
 }
 
 module "build" {
-  source    = "git::https://github.com/cloudposse/tf_codebuild.git?ref=tags/0.1.0"
-  namespace = "${var.namespace}"
-  name      = "${var.name}-build"
-  stage     = "${var.stage}"
-
+  source        = "git::https://github.com/cloudposse/tf_codebuild.git?ref=tags/0.3.0"
+  namespace     = "${var.namespace}"
+  name          = "${var.name}-build"
+  stage         = "${var.stage}"
   image         = "${var.build_image}"
   instance_size = "${var.build_instance_size}"
+  delimiter     = "${var.delimiter}"
+  attributes    = "${var.attributes}"
+  tags          = "${var.tags}"
 }
 
 resource "aws_iam_role_policy_attachment" "codebuild_s3" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,18 @@ variable "build_image" {
 variable "build_instance_size" {
   default = "BUILD_GENERAL1_SMALL"
 }
+
+variable "delimiter" {
+  type    = "string"
+  default = "-"
+}
+
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}


### PR DESCRIPTION
## What

* Propagate `attributes` and `tags` from `variables.tf` to the internal `label` module
* Bump `tf_codebuild` version to `0.3.0`


## Why

* The internal `label` module's `attributes` and `tags` should be visible from outside of the top-level module
* `tf_codebuild` version `0.3.0` allows `CodeBuild` to save `Docker` images to `Amazon ECR`

